### PR TITLE
allow multiple classes

### DIFF
--- a/summernote-image-shapes.js
+++ b/summernote-image-shapes.js
@@ -51,9 +51,12 @@
                 $button.data('value'),
                 lang.imageShapes.tooltipShapeOptions
               );
-              $.each(options.imageShapes.shapes, function (index,value) {
-                $img.removeClass(value);
-              });
+              // remove applied classes only if None option chosen
+              if(options.imageShapes.shapes[index]==''){
+                $.each(options.imageShapes.shapes, function (index,value) {
+                  $img.removeClass(value);
+                });
+              }
               $img.addClass(options.imageShapes.shapes[index]);
               context.invoke('editor.afterCommand');
             }


### PR DESCRIPTION
By only removing classes only if "None" is chosen, this allows a user to create a circular, responsive thumbnail, for example.  None resets everything, so any combo is possible.